### PR TITLE
Changed _getBookmarkDataForTemplate function 

### DIFF
--- a/src/bookmarks.js
+++ b/src/bookmarks.js
@@ -441,12 +441,16 @@ var Bookmarks = L.Control.extend( /**  @lends Bookmarks.prototype */ {
    * @return {Object}
    */
   _getBookmarkDataForTemplate: function(bookmark) {
-    return {
-      coords: this.formatCoords(bookmark.latlng),
-      name: this.formatName(bookmark.name),
-      zoom: bookmark.zoom,
-      id: bookmark.id
-    };
+      if (this.options.getBookmarkDataForTemplate) {
+        return this.options.getBookmarkDataForTemplate.call(this, bookmark);
+      } else { 
+      return {
+        coords: this.formatCoords(bookmark.latlng),
+        name: this.formatName(bookmark.name),
+        zoom: bookmark.zoom,
+        id: bookmark.id
+        };
+      }
   },
 
   /**


### PR DESCRIPTION
to call the function passed to options if it exists, otherwise return the default functionality. This allows for access to custom field data in the bookmark template. This resolves issue #7.